### PR TITLE
[FEAT/#3] 엔티티 생성

### DIFF
--- a/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
@@ -1,0 +1,53 @@
+package com.rootandfruit.server.domain;
+
+import com.rootandfruit.server.global.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "deliveryinfo")
+public class DeliveryInfo extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "sender_name")
+    private String senderName;
+
+    @Column(name = "sender_phone")
+    private String senderPhone;
+
+    @Column(name = "recipient_name")
+    private String recipientName;
+
+    @Column(name = "recipient_phone")
+    private String recipientPhone;
+
+    @Column(name = "recipient_address")
+    private String recipientAddress;
+
+    @Column(name = "recipient_address_detail")
+    private String recipientAddressDetail;
+
+    @Column(name = "delivery_date")
+    private LocalDate deliveryDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_status", nullable = false)
+    private DeliveryStatus deliveryStatus;
+
+}

--- a/src/main/java/com/rootandfruit/server/domain/Orders.java
+++ b/src/main/java/com/rootandfruit/server/domain/Orders.java
@@ -1,0 +1,56 @@
+package com.rootandfruit.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders")
+public class Orders {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "product_count")
+    private int productCount;
+
+    @Column(name = "order_number")
+    private int orderNumber;
+
+    // Order와 Product 간의 다대일 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    // Order와 DeliveryInfo 간의 다대일 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "delivery_info_id", nullable = false)
+    private DeliveryInfo deliveryInfo;
+
+    @Builder
+    private Orders(
+            final int productCount,
+            final int orderNumber,
+            final Product product,
+            final DeliveryInfo deliveryInfo
+    ) {
+        this.productCount = productCount;
+        this.orderNumber = orderNumber;
+        this.product = product;
+        this.deliveryInfo = deliveryInfo;
+    }
+}

--- a/src/main/java/com/rootandfruit/server/domain/Product.java
+++ b/src/main/java/com/rootandfruit/server/domain/Product.java
@@ -1,0 +1,35 @@
+package com.rootandfruit.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "product")
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "product_name")
+    private String productName ;
+
+    @Column(name = "price")
+    private int price ;
+
+    @Column(name = "is_sailed")
+    private boolean isSailed ;
+
+    @Column(name = "is_deleted")
+    private boolean is_deleted ;
+}


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
close #3 

## 💻 작업 내용
* 필요한 엔티티들을 생성했습니다.
### DeliveryInfo
* 발신자, 수신자의 정보와 배송지 정보, 배송상태, 베송날짜 등의 배송정보를 저장하는 테이블

### Product
* 상품의 가격과 이름을 저장하는 테이블
* 추가적으로 주문단계에서 보여줄 상품과, 관리자 페이지의 상품관리 페이지에서 보여줄 상품을 표시하는 컬럼이 존재함

### Orders
* 배송지정보와 상품을 엮어서 몇개를 주문했는지 저장하는 주문내역 테이블
* 동일한 수신자에게 여러개의 상품을 보낼 수 있기 때문에, 중복된 배송정보가 존재할 수 있음

추후 더 좋은 방법이 있다면 수정할 예정

## 💭 내가 알게 된 부분
<!-- 새롭게 알게 된 부분 가볍게 기록하기 (기록하면서 개발하기!) -->
* Order은 MySql의 예약어라 테이블의 이름으로 사용할 수 없어서, Orders라는 이름으로 대체했습니다.

## 📸 스크린샷
![rootandfruit](https://github.com/user-attachments/assets/492c611a-d639-48c9-a317-3b028d407523)

