### PR TITLE
[FIX/#5] 도커 배포 파일 수정 및 배송상태 추가

### DIFF
--- a/.github/workflows/DOCKER-CD.yml
+++ b/.github/workflows/DOCKER-CD.yml
@@ -1,7 +1,7 @@
 name: DOCKER-CD
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "develop" ]
 
 jobs:
   ci:

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryStatus.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryStatus.java
@@ -1,0 +1,20 @@
+package com.rootandfruit.server.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum DeliveryStatus {
+    // 접수완료
+    ORDER_ACCEPTED("ORDER_ACCEPTED"),
+    // 결제완료
+    PAYMENT_COMPLETED("PAYMENT_COMPLETED"),
+    // 결제취소
+    PAYMENT_CANCELED("PAYMENT_CANCELED"),
+    // 발송완료
+    ORDER_SHIPPED("ORDER_SHIPPED");
+
+    private final String deliveryStatus;
+}


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
close #5 

## 💻 작업 내용
* 도커의 배포 브랜치를 develop으로 수정
* 배송상태 enum 클래스 추가

## 💭 내가 알게 된 부분
* codedeploy를 이용한 배포방식과는 달리 도커를 이용한 자동화 배포에서, .github/workflows/DOCKER-CD.yml 파일을 통해 배포의 트리거가 이루어지는 것이였습니다.
* 원격 저장소에만 있던 해당 파일을 로컬에 가져온 후, 배포의 기준이 되는 브랜치를 develop으로 수정하니 CI/CD가 정상적으로 작동하였습니다.