### PR TITLE
[FEAT] 주문 접수 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     // ACTUATOR
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // SWAGER
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/rootandfruit/server/RootAndFruitServerApplication.java
+++ b/src/main/java/com/rootandfruit/server/RootAndFruitServerApplication.java
@@ -1,0 +1,13 @@
+package com.rootandfruit.server;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RootAndFruitServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(RootAndFruitServerApplication.class, args);
+    }
+
+}

--- a/src/main/java/com/rootandfruit/server/controller/OrdersController.java
+++ b/src/main/java/com/rootandfruit/server/controller/OrdersController.java
@@ -1,0 +1,26 @@
+package com.rootandfruit.server.controller;
+
+import com.rootandfruit.server.dto.OrderRequestDto;
+import com.rootandfruit.server.service.OrdersService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/")
+@RequiredArgsConstructor
+public class OrdersController {
+
+    private final OrdersService ordersService;
+
+    @PostMapping("orders")
+    public ResponseEntity<Void> order(
+            @RequestBody OrderRequestDto orderRequestDto
+            ){
+        ordersService.order(orderRequestDto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
@@ -1,6 +1,6 @@
 package com.rootandfruit.server.domain;
 
-import com.rootandfruit.server.global.BaseTimeEntity;
+import com.rootandfruit.server.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
@@ -1,5 +1,7 @@
 package com.rootandfruit.server.domain;
 
+import com.rootandfruit.server.dto.OrderRequestDto;
+import com.rootandfruit.server.dto.RecipientDto;
 import com.rootandfruit.server.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -11,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,29 +28,62 @@ public class DeliveryInfo extends BaseTimeEntity {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "sender_name")
+    @Column(name = "sender_name", nullable = false)
     private String senderName;
 
-    @Column(name = "sender_phone")
+    @Column(name = "sender_phone", nullable = false)
     private String senderPhone;
 
-    @Column(name = "recipient_name")
+    @Column(name = "recipient_name", nullable = false)
     private String recipientName;
 
-    @Column(name = "recipient_phone")
+    @Column(name = "recipient_phone", nullable = false)
     private String recipientPhone;
 
-    @Column(name = "recipient_address")
+    @Column(name = "recipient_address", nullable = false)
     private String recipientAddress;
 
-    @Column(name = "recipient_address_detail")
+    @Column(name = "recipient_address_detail", nullable = false)
     private String recipientAddressDetail;
 
-    @Column(name = "delivery_date")
+    @Column(name = "delivery_date", nullable = false)
     private LocalDate deliveryDate;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "delivery_status", nullable = false)
     private DeliveryStatus deliveryStatus;
 
+    @Builder
+    private DeliveryInfo(
+            final String senderName,
+            final String senderPhone,
+            final String recipientName,
+            final String recipientPhone,
+            final String recipientAddress,
+            final String recipientAddressDetail,
+            final LocalDate deliveryDate,
+            final  DeliveryStatus deliveryStatus
+    ){
+        this.senderName = senderName;
+        this.senderPhone = senderPhone;
+        this.recipientName = recipientName;
+        this.recipientPhone = recipientPhone;
+        this.recipientAddress = recipientAddress;
+        this.recipientAddressDetail = recipientAddressDetail;
+        this.deliveryDate = deliveryDate;
+        this.deliveryStatus = deliveryStatus;
+    }
+
+    public static DeliveryInfo createDeliveryInfo(final OrderRequestDto orderRequestDto, final RecipientDto recipientDto) {
+        return DeliveryInfo.builder()
+                .senderName(orderRequestDto.senderName())
+                .senderPhone(orderRequestDto.senderPhone())
+                .recipientName(recipientDto.recipientName())
+                .recipientPhone(recipientDto.recipientPhone())
+                .recipientAddress(recipientDto.recipientAddress())
+                .recipientAddressDetail(recipientDto.recipientAddressDetail())
+                .deliveryDate(recipientDto.deliveryDate())
+                .deliveryStatus(DeliveryStatus.ORDER_ACCEPTED)
+                .build();
+    }
 }

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryStatus.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryStatus.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum DeliveryStatus {
+
     // 접수완료
     ORDER_ACCEPTED("ORDER_ACCEPTED"),
     // 결제완료

--- a/src/main/java/com/rootandfruit/server/domain/Member.java
+++ b/src/main/java/com/rootandfruit/server/domain/Member.java
@@ -1,0 +1,56 @@
+package com.rootandfruit.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    @Column(name = "is_marketing_consent", nullable = false)
+    private boolean isMarketingConsent;
+
+    @Builder
+    private Member(
+            final String name,
+            final String phone,
+            final boolean isMarketingConsent
+    ) {
+        this.name = name;
+        this.phone = phone;
+        this.isMarketingConsent = isMarketingConsent;
+    }
+
+    public static Member createMember(
+            final String name,
+            final String phone,
+            final boolean isMarketingConsent
+    ) {
+        return Member.builder()
+                .name(name)
+                .phone(phone)
+                .isMarketingConsent(isMarketingConsent)
+                .build();
+    }
+}

--- a/src/main/java/com/rootandfruit/server/domain/OrderMetaData.java
+++ b/src/main/java/com/rootandfruit/server/domain/OrderMetaData.java
@@ -1,0 +1,35 @@
+package com.rootandfruit.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ordermetadate")
+public class OrderMetaData {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    // 주문번호 시퀀스 값
+    @Column(name = "order_number_sequence")
+    private int orderNumberSequence = 1000;
+
+    // 배송 가능 날짜 범위
+    @Column(name = "allowed_delivery_days")
+    private int allowedDeliveryDays;
+
+    public int incrementOrderNumberSequence() {
+        return ++this.orderNumberSequence;
+    }
+}

--- a/src/main/java/com/rootandfruit/server/domain/Orders.java
+++ b/src/main/java/com/rootandfruit/server/domain/Orders.java
@@ -1,5 +1,6 @@
 package com.rootandfruit.server.domain;
 
+import com.rootandfruit.server.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,25 +19,30 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "orders")
-public class Orders {
+public class Orders extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "product_count")
+    @Column(name = "product_count", nullable = false)
     private int productCount;
 
-    @Column(name = "order_number")
+    @Column(name = "order_number", nullable = false)
     private int orderNumber;
 
-    // Order와 Product 간의 다대일 관계
+    // 주문과 사용자 간의 다대일 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 주문과 상품 간의 다대일 관계
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
-    // Order와 DeliveryInfo 간의 다대일 관계
+    // 주문과 배송정보 간의 다대일 관계
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "delivery_info_id", nullable = false)
     private DeliveryInfo deliveryInfo;
@@ -45,12 +51,30 @@ public class Orders {
     private Orders(
             final int productCount,
             final int orderNumber,
+            final Member member,
             final Product product,
             final DeliveryInfo deliveryInfo
     ) {
         this.productCount = productCount;
         this.orderNumber = orderNumber;
+        this.member = member;
         this.product = product;
         this.deliveryInfo = deliveryInfo;
+    }
+
+    public static Orders createOrders(
+            final int productCount,
+            final int orderNumber,
+            final Member member,
+            final Product product,
+            final DeliveryInfo deliveryInfo
+    ) {
+        return Orders.builder()
+                .productCount(productCount)
+                .orderNumber(orderNumber)
+                .member(member)
+                .product(product)
+                .deliveryInfo(deliveryInfo)
+                .build();
     }
 }

--- a/src/main/java/com/rootandfruit/server/domain/Product.java
+++ b/src/main/java/com/rootandfruit/server/domain/Product.java
@@ -1,5 +1,6 @@
 package com.rootandfruit.server.domain;
 
+import com.rootandfruit.server.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -14,17 +15,17 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "product")
-public class Product {
+public class Product extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "product_name")
+    @Column(name = "product_name", nullable = false)
     private String productName ;
 
-    @Column(name = "price")
+    @Column(name = "price", nullable = false)
     private int price ;
 
     @Column(name = "is_sailed")

--- a/src/main/java/com/rootandfruit/server/dto/OrderRequestDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderRequestDto.java
@@ -1,0 +1,12 @@
+package com.rootandfruit.server.dto;
+
+import jakarta.persistence.Column;
+import java.time.LocalDate;
+import java.util.List;
+
+public record OrderRequestDto(
+        String senderName,
+        String senderPhone,
+        List<RecipientDto> recipientInfo
+) {
+}

--- a/src/main/java/com/rootandfruit/server/dto/OrderRequestDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderRequestDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record OrderRequestDto(
         String senderName,
         String senderPhone,
+        boolean isMarketingConsent,
         List<RecipientDto> recipientInfo
 ) {
 }

--- a/src/main/java/com/rootandfruit/server/dto/ProductDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/ProductDto.java
@@ -1,7 +1,7 @@
 package com.rootandfruit.server.dto;
 
 public record ProductDto(
-        String productName,
+        Long productId,
         int productCount
 ) {
 }

--- a/src/main/java/com/rootandfruit/server/dto/ProductDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/ProductDto.java
@@ -1,0 +1,7 @@
+package com.rootandfruit.server.dto;
+
+public record ProductDto(
+        String productName,
+        int productCount
+) {
+}

--- a/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
@@ -9,6 +9,6 @@ public record RecipientDto(
         String recipientAddress,
         String recipientAddressDetail,
         List<ProductDto> productInfo,
-        String deliveryDate
+        LocalDate deliveryDate
 ) {
 }

--- a/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
@@ -1,0 +1,14 @@
+package com.rootandfruit.server.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record RecipientDto(
+        String recipientName,
+        String recipientPhone,
+        String recipientAddress,
+        String recipientAddressDetail,
+        List<ProductDto> productInfo,
+        LocalDate deliveryDate
+) {
+}

--- a/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
@@ -9,6 +9,6 @@ public record RecipientDto(
         String recipientAddress,
         String recipientAddressDetail,
         List<ProductDto> productInfo,
-        LocalDate deliveryDate
+        String deliveryDate
 ) {
 }

--- a/src/main/java/com/rootandfruit/server/global/common/BaseTimeEntity.java
+++ b/src/main/java/com/rootandfruit/server/global/common/BaseTimeEntity.java
@@ -1,0 +1,20 @@
+package com.rootandfruit.server.global.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/rootandfruit/server/global/common/ResponseDto.java
+++ b/src/main/java/com/rootandfruit/server/global/common/ResponseDto.java
@@ -1,0 +1,19 @@
+package com.rootandfruit.server.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.rootandfruit.server.global.exception.ErrorType;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ResponseDto<T>(
+        String code,
+        T data,
+        String message
+) {
+    public static <T> ResponseDto<T> success(final T data) {
+        return new ResponseDto<>("success", data, null);
+    }
+
+    public static <T> ResponseDto<T> fail(ErrorType errorType) {
+        return new ResponseDto<>(errorType.getCode(), null, errorType.getMessage());
+    }
+}

--- a/src/main/java/com/rootandfruit/server/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/rootandfruit/server/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.rootandfruit.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/rootandfruit/server/global/exception/CustomException.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/CustomException.java
@@ -1,0 +1,18 @@
+package com.rootandfruit.server.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorType errorType;
+
+    public CustomException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+
+    public int getHttpStatus() {
+        return errorType.getHttpStatusCode();
+    }
+}
+

--- a/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
@@ -1,0 +1,38 @@
+package com.rootandfruit.server.global.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorType {
+
+    /**
+     * 400 BAD REQUEST
+     */
+    // 표준 오류
+    REQUEST_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "40001", "잘못된 요청입니다."),
+    INVALID_TYPE_ERROR(HttpStatus.BAD_REQUEST, "40002", "잘못된 타입이 입력되었습니다."),
+    INVALID_MISSING_HEADER_ERROR(HttpStatus.BAD_REQUEST, "40003", "요청에 필요한 헤더값이 존재하지 않습니다."),
+    INVALID_HTTP_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "40004", "요청 형식이 허용된 형식과 다릅니다."),
+    INVALID_HTTP_METHOD_ERROR(HttpStatus.BAD_REQUEST, "40005", "지원되지 않는 HTTP method 요청입니다."),
+
+    /**
+     * 404 NOT FOUND
+     */
+
+    /**
+     * 500 INTERNAL SERVER ERROR
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50001", "알 수 없는 서버 에러가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
@@ -22,6 +22,8 @@ public enum ErrorType {
     /**
      * 404 NOT FOUND
      */
+    NOT_FOUND_PRODUCT_ERROR(HttpStatus.NOT_FOUND, "40401", "존재하지 않는 상품입니다."),
+    NOT_FOUND_ORDER_META_DATA_ERROR(HttpStatus.NOT_FOUND, "4040품1", "주문 메타데이터가 존재하지 않습니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/com/rootandfruit/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.rootandfruit.server.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 비즈니스 로직에서 발생한 예외 (언체크)
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorType> handleBusinessException(CustomException e) {
+        return ResponseEntity
+                .status(e.getErrorType().getHttpStatus())
+                .body(e.getErrorType());
+    }
+}

--- a/src/main/java/com/rootandfruit/server/global/exception/ResponseDtoAdvice.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/ResponseDtoAdvice.java
@@ -1,0 +1,36 @@
+package com.rootandfruit.server.global.exception;
+
+import com.rootandfruit.server.global.common.ResponseDto;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(
+        basePackages = "com.rootandfruit.server"
+)
+public class ResponseDtoAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return !(returnType.getParameterType() == ResponseDto.class)
+                && MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response
+    ) {
+        if (body instanceof ErrorType)
+            return ResponseDto.fail((ErrorType) body);
+        return ResponseDto.success(body);
+    }
+}

--- a/src/main/java/com/rootandfruit/server/repository/DeliveryInfoRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/DeliveryInfoRepository.java
@@ -1,0 +1,7 @@
+package com.rootandfruit.server.repository;
+
+import com.rootandfruit.server.domain.DeliveryInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryInfoRepository extends JpaRepository<DeliveryInfo, Long> {
+}

--- a/src/main/java/com/rootandfruit/server/repository/MemberRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.rootandfruit.server.repository;
+
+import com.rootandfruit.server.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/rootandfruit/server/repository/OrderMetaDataRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrderMetaDataRepository.java
@@ -1,0 +1,18 @@
+package com.rootandfruit.server.repository;
+
+import com.rootandfruit.server.domain.OrderMetaData;
+import com.rootandfruit.server.domain.Product;
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderMetaDataRepository extends JpaRepository<OrderMetaData, Long> {
+
+    Optional<OrderMetaData> findOrderMetaDataById(Long id);
+
+    default OrderMetaData findOrderMetaDataByIdOrThrow(Long id) {
+        return findOrderMetaDataById(id)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_ORDER_META_DATA_ERROR));
+    }
+}

--- a/src/main/java/com/rootandfruit/server/repository/OrdersRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersRepository.java
@@ -1,0 +1,7 @@
+package com.rootandfruit.server.repository;
+
+import com.rootandfruit.server.domain.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrdersRepository extends JpaRepository<Orders, Long> {
+}

--- a/src/main/java/com/rootandfruit/server/repository/ProductRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/ProductRepository.java
@@ -1,0 +1,16 @@
+package com.rootandfruit.server.repository;
+
+import com.rootandfruit.server.domain.Product;
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    Optional<Product> findProductById(Long id);
+
+    default Product findProductByIdOrThrow(Long id) {
+        return findProductById(id)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_PRODUCT_ERROR));
+    }
+}

--- a/src/main/java/com/rootandfruit/server/service/OrdersService.java
+++ b/src/main/java/com/rootandfruit/server/service/OrdersService.java
@@ -1,0 +1,60 @@
+package com.rootandfruit.server.service;
+
+import com.rootandfruit.server.domain.DeliveryInfo;
+import com.rootandfruit.server.domain.Member;
+import com.rootandfruit.server.domain.OrderMetaData;
+import com.rootandfruit.server.domain.Orders;
+import com.rootandfruit.server.domain.Product;
+import com.rootandfruit.server.dto.OrderRequestDto;
+import com.rootandfruit.server.repository.DeliveryInfoRepository;
+import com.rootandfruit.server.repository.MemberRepository;
+import com.rootandfruit.server.repository.OrderMetaDataRepository;
+import com.rootandfruit.server.repository.OrdersRepository;
+import com.rootandfruit.server.repository.ProductRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrdersService {
+
+    private final MemberRepository memberRepository;
+    private final ProductRepository productRepository;
+    private final DeliveryInfoRepository deliveryInfoRepository;
+    private final OrdersRepository ordersRepository;
+    private final OrderMetaDataRepository orderMetaDataRepository;
+
+    @Transactional
+    public void order(OrderRequestDto orderRequestDto){
+        Member member = Member.createMember(orderRequestDto.senderName(), orderRequestDto.senderPhone(),
+                orderRequestDto.isMarketingConsent());
+        memberRepository.save(member);
+
+        orderRequestDto.recipientInfo().forEach(recipientDto -> {
+
+            DeliveryInfo deliveryInfo = DeliveryInfo.createDeliveryInfo(orderRequestDto, recipientDto);
+            deliveryInfoRepository.save(deliveryInfo);
+
+            OrderMetaData orderMetaData = orderMetaDataRepository.findOrderMetaDataByIdOrThrow(1L);
+            int currentOrderNumber = orderMetaData.incrementOrderNumberSequence();
+
+            recipientDto.productInfo().forEach(productDto -> {
+                log.info(String.valueOf(productDto.productId()));
+                Product product = productRepository.findProductByIdOrThrow(productDto.productId());
+                Orders order = Orders.createOrders(
+                        productDto.productCount(),
+                        currentOrderNumber,
+                        member,
+                        product,
+                        deliveryInfo
+                );
+
+                ordersRepository.save(order);
+            });
+        });
+    }
+}

--- a/src/test/java/com/rootandfruit/server/RootAndFruitServerApplicationTests.java
+++ b/src/test/java/com/rootandfruit/server/RootAndFruitServerApplicationTests.java
@@ -1,0 +1,13 @@
+package com.rootandfruit.server;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class RootAndFruitServerApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- close #7 

### ✅ todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] ERD 확정
- [x] 주문접수 서비스 로직 구현
- [x] 스웨거 연동

## 💻 작업 내용
<!-- 작업한 내용 리뷰어가 보기 편하게 기록해두기 -->
- 마케팅 활용 동의를 표시하기 위해서 멤버 테이블을 추가했습니다.
- 배송정보와 멤버, 상품 종류와 수량이 결정되면 주문 테이블에 매핑을 해서 주문한 상품별로 튜플이 추가됩니다.
- 한 사람이 엄청나게 많은 상품을 주문하는 경우는 흔치 않을 것이라고 생각해서 해당 구조를 채택했습니다. (사람별로 어떤 것을 주문했는지 한 눈에 보기 편하도록)
- 주문번호의 시퀀스값과 배송 날짜 범위를 관리하기 위해 "주문 메타 데이터"라는 싱글테이블을 추가했습니다.
<img width="1184" alt="image" src="https://github.com/user-attachments/assets/80511bf9-62c4-4630-8226-c40201a728ff">
