### PR TITLE
[FEAT] 주문/주문내역 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ dependencies {
     // SWAGER
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+    // QUERYDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0' // 쿼리 파라미터 로그 남기기
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/rootandfruit/server/controller/OrdersController.java
+++ b/src/main/java/com/rootandfruit/server/controller/OrdersController.java
@@ -1,9 +1,12 @@
 package com.rootandfruit.server.controller;
 
+import com.rootandfruit.server.dto.OrderNumberResponseDto;
 import com.rootandfruit.server.dto.OrderRequestDto;
 import com.rootandfruit.server.service.OrdersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,11 +19,18 @@ public class OrdersController {
 
     private final OrdersService ordersService;
 
-    @PostMapping("orders")
+    @PostMapping("order")
     public ResponseEntity<Void> order(
             @RequestBody OrderRequestDto orderRequestDto
             ){
         ordersService.order(orderRequestDto);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("order/{orderNumber}")
+    public ResponseEntity<OrderNumberResponseDto> order(
+            @PathVariable int orderNumber
+    ){
+        return ResponseEntity.ok(ordersService.getOrderByOrderNumber(orderNumber));
     }
 }

--- a/src/main/java/com/rootandfruit/server/controller/OrdersController.java
+++ b/src/main/java/com/rootandfruit/server/controller/OrdersController.java
@@ -2,7 +2,10 @@ package com.rootandfruit.server.controller;
 
 import com.rootandfruit.server.dto.OrderNumberResponseDto;
 import com.rootandfruit.server.dto.OrderRequestDto;
+import com.rootandfruit.server.dto.OrderResponseDto;
 import com.rootandfruit.server.service.OrdersService;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,5 +36,21 @@ public class OrdersController {
             @PathVariable int orderNumber
     ){
         return ResponseEntity.ok(ordersService.getOrderByOrderNumber(orderNumber));
+    }
+
+    @GetMapping("/order")
+    public ResponseEntity<OrderResponseDto> searchFieldPosition(
+            @RequestParam(required = false) final LocalDate orderReceivedDate,
+            @RequestParam(required = false) final LocalDate deliveryDate,
+            @RequestParam(required = false) final String productName,
+            @RequestParam(required = false) final String deliveryStatus
+    ) {
+
+        return ResponseEntity.ok(ordersService.searchOrder(
+                orderReceivedDate,
+                deliveryDate,
+                productName,
+                deliveryStatus
+        ));
     }
 }

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
@@ -46,6 +46,9 @@ public class DeliveryInfo extends BaseTimeEntity {
     @Column(name = "recipient_address_detail", nullable = false)
     private String recipientAddressDetail;
 
+    @Column(name = "recipient_post_code", nullable = false)
+    private int recipientPostCode;
+
     @Column(name = "delivery_date", nullable = false)
     private LocalDate deliveryDate;
 
@@ -61,6 +64,7 @@ public class DeliveryInfo extends BaseTimeEntity {
             final String recipientPhone,
             final String recipientAddress,
             final String recipientAddressDetail,
+            final int recipientPostCode,
             final LocalDate deliveryDate,
             final  DeliveryStatus deliveryStatus
     ){
@@ -70,6 +74,7 @@ public class DeliveryInfo extends BaseTimeEntity {
         this.recipientPhone = recipientPhone;
         this.recipientAddress = recipientAddress;
         this.recipientAddressDetail = recipientAddressDetail;
+        this.recipientPostCode = recipientPostCode;
         this.deliveryDate = deliveryDate;
         this.deliveryStatus = deliveryStatus;
     }
@@ -82,6 +87,7 @@ public class DeliveryInfo extends BaseTimeEntity {
                 .recipientPhone(recipientDto.recipientPhone())
                 .recipientAddress(recipientDto.recipientAddress())
                 .recipientAddressDetail(recipientDto.recipientAddressDetail())
+                .recipientPostCode(recipientDto.recipientPostCode())
                 .deliveryDate(recipientDto.deliveryDate())
                 .deliveryStatus(DeliveryStatus.ORDER_ACCEPTED)
                 .build();

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
@@ -47,7 +47,7 @@ public class DeliveryInfo extends BaseTimeEntity {
     private String recipientAddressDetail;
 
     @Column(name = "recipient_post_code", nullable = false)
-    private int recipientPostCode;
+    private String recipientPostCode;
 
     @Column(name = "delivery_date", nullable = false)
     private LocalDate deliveryDate;
@@ -64,7 +64,7 @@ public class DeliveryInfo extends BaseTimeEntity {
             final String recipientPhone,
             final String recipientAddress,
             final String recipientAddressDetail,
-            final int recipientPostCode,
+            final String recipientPostCode,
             final LocalDate deliveryDate,
             final  DeliveryStatus deliveryStatus
     ){

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryStatus.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryStatus.java
@@ -1,5 +1,7 @@
 package com.rootandfruit.server.domain;
 
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -18,4 +20,13 @@ public enum DeliveryStatus {
     ORDER_SHIPPED("발송완료");
 
     private final String deliveryStatus;
+
+    public static DeliveryStatus fromString(String status) {
+        for (DeliveryStatus deliveryStatus : DeliveryStatus.values()) {
+            if (deliveryStatus.getDeliveryStatus().equals(status)) {
+                return deliveryStatus;
+            }
+        }
+        throw new CustomException(ErrorType.INVALID_DELIVERY_STATUS_ERROR);
+    }
 }

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryStatus.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryStatus.java
@@ -9,13 +9,13 @@ import lombok.RequiredArgsConstructor;
 public enum DeliveryStatus {
 
     // 접수완료
-    ORDER_ACCEPTED("ORDER_ACCEPTED"),
+    ORDER_ACCEPTED("접수완료"),
     // 결제완료
-    PAYMENT_COMPLETED("PAYMENT_COMPLETED"),
+    PAYMENT_COMPLETED("결제완료"),
     // 결제취소
-    PAYMENT_CANCELED("PAYMENT_CANCELED"),
+    PAYMENT_CANCELED("결제취소"),
     // 발송완료
-    ORDER_SHIPPED("ORDER_SHIPPED");
+    ORDER_SHIPPED("발송완료");
 
     private final String deliveryStatus;
 }

--- a/src/main/java/com/rootandfruit/server/dto/OrderDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderDto.java
@@ -1,0 +1,27 @@
+package com.rootandfruit.server.dto;
+
+import java.time.LocalDate;
+
+public record OrderDto(
+        String senderName,
+        String recipientName,
+        String productName,
+        int productCount,
+        String deliveryStatus,
+        LocalDate orderReceivedDate,
+        LocalDate deliveryDate
+) {
+    public static OrderDto of(
+            final String senderName,
+            final String recipientName,
+            final String productName,
+            final int productCount,
+            final String deliveryStatus,
+            final LocalDate orderReceivedDate,
+            final LocalDate deliveryDate
+    ) {
+        return new OrderDto(
+                senderName, recipientName, productName, productCount, deliveryStatus, orderReceivedDate, deliveryDate
+        );
+    }
+}

--- a/src/main/java/com/rootandfruit/server/dto/OrderDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderDto.java
@@ -1,0 +1,19 @@
+package com.rootandfruit.server.dto;
+
+public record OrderDto(
+        String productName,
+         int productCount,
+         String orderState,
+         int price
+) {
+    public static OrderDto of(
+            final String productName,
+            final int productCount,
+            final String orderState,
+            final int price
+    ) {
+        return new OrderDto(
+                productName, productCount, orderState, price
+        );
+    }
+}

--- a/src/main/java/com/rootandfruit/server/dto/OrderNumberDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderNumberDto.java
@@ -3,17 +3,17 @@ package com.rootandfruit.server.dto;
 public record OrderDto(
         String productName,
          int productCount,
-         String orderState,
+         String deliveryStatus,
          int price
 ) {
     public static OrderDto of(
             final String productName,
             final int productCount,
-            final String orderState,
+            final String deliveryStatus,
             final int price
     ) {
         return new OrderDto(
-                productName, productCount, orderState, price
+                productName, productCount, deliveryStatus, price
         );
     }
 }

--- a/src/main/java/com/rootandfruit/server/dto/OrderNumberDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderNumberDto.java
@@ -1,18 +1,18 @@
 package com.rootandfruit.server.dto;
 
-public record OrderDto(
+public record OrderNumberDto(
         String productName,
          int productCount,
          String deliveryStatus,
          int price
 ) {
-    public static OrderDto of(
+    public static OrderNumberDto of(
             final String productName,
             final int productCount,
             final String deliveryStatus,
             final int price
     ) {
-        return new OrderDto(
+        return new OrderNumberDto(
                 productName, productCount, deliveryStatus, price
         );
     }

--- a/src/main/java/com/rootandfruit/server/dto/OrderNumberResponseDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderNumberResponseDto.java
@@ -4,12 +4,12 @@ import java.util.List;
 
 public record OrderNumberResponseDto(
         String senderName,
-        List<OrderDto> orderList,
+        List<OrderNumberDto> orderList,
         int totalPrice
 ) {
     public static OrderNumberResponseDto of(
             final String senderName,
-            final List<OrderDto> orderList,
+            final List<OrderNumberDto> orderList,
             final int totalPrice
     ) {
         return new OrderNumberResponseDto(

--- a/src/main/java/com/rootandfruit/server/dto/OrderNumberResponseDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderNumberResponseDto.java
@@ -1,0 +1,19 @@
+package com.rootandfruit.server.dto;
+
+import java.util.List;
+
+public record OrderNumberResponseDto(
+        String senderName,
+        List<OrderDto> orderList,
+        int totalPrice
+) {
+    public static OrderNumberResponseDto of(
+            final String senderName,
+            final List<OrderDto> orderList,
+            final int totalPrice
+    ) {
+        return new OrderNumberResponseDto(
+                senderName, orderList, totalPrice
+        );
+    }
+}

--- a/src/main/java/com/rootandfruit/server/dto/OrderResponseDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderResponseDto.java
@@ -1,0 +1,13 @@
+package com.rootandfruit.server.dto;
+
+import java.util.List;
+
+public record OrderResponseDto(
+        List<OrderDto> orderList
+) {
+    public static OrderResponseDto of(
+            List<OrderDto> orderList
+    ) {
+        return new OrderResponseDto(orderList);
+    }
+}

--- a/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
@@ -8,7 +8,7 @@ public record RecipientDto(
         String recipientPhone,
         String recipientAddress,
         String recipientAddressDetail,
-        int recipientPostCode,
+        String recipientPostCode,
         List<ProductDto> productInfo,
         LocalDate deliveryDate
 ) {

--- a/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/RecipientDto.java
@@ -8,6 +8,7 @@ public record RecipientDto(
         String recipientPhone,
         String recipientAddress,
         String recipientAddressDetail,
+        int recipientPostCode,
         List<ProductDto> productInfo,
         LocalDate deliveryDate
 ) {

--- a/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
@@ -18,6 +18,7 @@ public enum ErrorType {
     INVALID_MISSING_HEADER_ERROR(HttpStatus.BAD_REQUEST, "40003", "요청에 필요한 헤더값이 존재하지 않습니다."),
     INVALID_HTTP_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "40004", "요청 형식이 허용된 형식과 다릅니다."),
     INVALID_HTTP_METHOD_ERROR(HttpStatus.BAD_REQUEST, "40005", "지원되지 않는 HTTP method 요청입니다."),
+    INVALID_DELIVERY_STATUS_ERROR(HttpStatus.BAD_REQUEST, "40006", "잘못된 배송상태가 입력되었습니다."),
 
     /**
      * 404 NOT FOUND

--- a/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
@@ -23,7 +23,8 @@ public enum ErrorType {
      * 404 NOT FOUND
      */
     NOT_FOUND_PRODUCT_ERROR(HttpStatus.NOT_FOUND, "40401", "존재하지 않는 상품입니다."),
-    NOT_FOUND_ORDER_META_DATA_ERROR(HttpStatus.NOT_FOUND, "4040품1", "주문 메타데이터가 존재하지 않습니다."),
+    NOT_FOUND_ORDER_META_DATA_ERROR(HttpStatus.NOT_FOUND, "40402", "주문 메타데이터가 존재하지 않습니다."),
+    NOT_FOUND_ORDER_ERROR(HttpStatus.NOT_FOUND, "40403", "주문번호에 대한 주문내역이 존재하지 않습니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/com/rootandfruit/server/repository/OrdersCustomRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersCustomRepository.java
@@ -1,0 +1,11 @@
+package com.rootandfruit.server.repository;
+
+import com.rootandfruit.server.domain.DeliveryStatus;
+import com.rootandfruit.server.domain.Orders;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface OrdersCustomRepository {
+    List<Orders> searchOrders(LocalDate orderReceivedDate, LocalDate deliveryDate, String productName,
+                              DeliveryStatus deliveryStatus);
+}

--- a/src/main/java/com/rootandfruit/server/repository/OrdersRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersRepository.java
@@ -1,14 +1,12 @@
 package com.rootandfruit.server.repository;
 
 import com.rootandfruit.server.domain.Orders;
-import com.rootandfruit.server.domain.Product;
 import com.rootandfruit.server.global.exception.CustomException;
 import com.rootandfruit.server.global.exception.ErrorType;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrdersRepository extends JpaRepository<Orders, Long> {
+public interface OrdersRepository extends JpaRepository<Orders, Long>, OrdersCustomRepository {
     List<Orders> findByOrderNumber(int orderNumber);
 
     default List<Orders> findByOrderNumberOrThrow(int orderNumber) {

--- a/src/main/java/com/rootandfruit/server/repository/OrdersRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersRepository.java
@@ -1,7 +1,21 @@
 package com.rootandfruit.server.repository;
 
 import com.rootandfruit.server.domain.Orders;
+import com.rootandfruit.server.domain.Product;
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
+    List<Orders> findByOrderNumber(int orderNumber);
+
+    default List<Orders> findByOrderNumberOrThrow(int orderNumber) {
+        List<Orders> orders = findByOrderNumber(orderNumber);
+        if (orders.isEmpty()) {
+            throw new CustomException(ErrorType.NOT_FOUND_ORDER_ERROR);
+        }
+        return orders;
+    }
 }

--- a/src/main/java/com/rootandfruit/server/repository/OrdersRepositoryImpl.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.rootandfruit.server.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.rootandfruit.server.domain.DeliveryStatus;
+import com.rootandfruit.server.domain.Orders;
+import com.rootandfruit.server.domain.QDeliveryInfo;
+import com.rootandfruit.server.domain.QOrders;
+import com.rootandfruit.server.domain.QProduct;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+
+public class OrdersRepositoryImpl implements OrdersCustomRepository{
+
+    private final JPAQueryFactory queryFactory;
+    private final QOrders orders = QOrders.orders;
+
+    public OrdersRepositoryImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);;
+    }
+
+    @Override
+    public List<Orders> searchOrders(LocalDate orderReceivedDate, LocalDate deliveryDate, String productName,
+                                     DeliveryStatus deliveryStatus) {
+        return queryFactory
+                .selectFrom(orders)
+                .join(orders.deliveryInfo, QDeliveryInfo.deliveryInfo)
+                .join(orders.product, QProduct.product)
+                .where(
+                        orderReceivedDate != null ? orders.createdAt.year().eq(orderReceivedDate.getYear())
+                                .and(orders.createdAt.month().eq(orderReceivedDate.getMonthValue()))
+                                .and(orders.createdAt.dayOfMonth().eq(orderReceivedDate.getDayOfMonth())) : null,
+                        ltDeliveryDate(deliveryDate),
+                        eqProductName(productName),
+                        eqDeliveryStatus(deliveryStatus)
+                )
+                .fetch();
+    }
+
+    private BooleanExpression ltDeliveryDate(LocalDate deliveryDate) {
+        return deliveryDate != null ? QDeliveryInfo.deliveryInfo.deliveryDate.before(deliveryDate) : null;
+    }
+
+    private BooleanExpression eqProductName(String productName) {
+        return productName != null ? QProduct.product.productName.eq(productName) : null;
+    }
+
+    private BooleanExpression eqDeliveryStatus(DeliveryStatus deliveryStatus) {
+        return deliveryStatus != null ? QDeliveryInfo.deliveryInfo.deliveryStatus.eq(
+                deliveryStatus) : null;
+    }
+}


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- close #9 

### ✅ todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 주문번호로 주문내역 조회 API
- [x] 주문접수 날짜, 배송날짜, 상품명, 배송상테로 필터링한 주문내역 조회 API

## 💻 작업 내용
<!-- 작업한 내용 리뷰어가 보기 편하게 기록해두기 -->
- 주문번호를 입력받아 주문내역을 조회하는 APi를 구현했습니다. (응답 데이터는 스크린샷 참고)
- 네 가지의 인자를 통해 주문내역을 필터링 조회하는 API를 구현했습니다. (응답 데이터는 스크린샷 참고)
- 배송날짜의 경우 인자로 받은 날짜보다 빠른 주문내역들을 조회했습니다.
- 추후, 필터링 조건이 변경될 경우를 감안하며 동적 쿼리 수정에 용이하도록 QeuryDsl을 사용했습니다.
- (상품명을 여러개로 조회한다는 등)

## 📸 스크린샷
- 주문번호로 조회 응답 데이터
<img width="380" alt="image" src="https://github.com/user-attachments/assets/1c7bd45b-9c83-4479-9a4f-9ff9faf0301b">

- 필터링 조회 응답 데이터
<img width="441" alt="image" src="https://github.com/user-attachments/assets/ef52a016-1084-4c65-9a73-2b0f2f5b65d0">
