### PR TITLE
[FEAT] 상품 CRUD API 구현

### DIFF
--- a/src/main/java/com/rootandfruit/server/controller/OrdersController.java
+++ b/src/main/java/com/rootandfruit/server/controller/OrdersController.java
@@ -38,7 +38,7 @@ public class OrdersController {
         return ResponseEntity.ok(ordersService.getOrderByOrderNumber(orderNumber));
     }
 
-    @GetMapping("/order")
+    @GetMapping("order")
     public ResponseEntity<OrderResponseDto> searchFieldPosition(
             @RequestParam(required = false) final LocalDate orderReceivedDate,
             @RequestParam(required = false) final LocalDate deliveryDate,

--- a/src/main/java/com/rootandfruit/server/controller/ProductController.java
+++ b/src/main/java/com/rootandfruit/server/controller/ProductController.java
@@ -1,0 +1,58 @@
+package com.rootandfruit.server.controller;
+
+import com.rootandfruit.server.dto.ProductRequestDto;
+import com.rootandfruit.server.dto.ProductResponseDto;
+import com.rootandfruit.server.dto.ProductSailedResponseDto;
+import com.rootandfruit.server.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping("product/all")
+    public ResponseEntity<ProductResponseDto> getProducts() {
+        return ResponseEntity.ok(productService.getAllProducts());
+    }
+
+    @GetMapping("product/sailed")
+    public ResponseEntity<ProductSailedResponseDto> getSailedProducts() {
+        return ResponseEntity.ok(productService.getSailedProducts());
+    }
+
+    @PatchMapping("product/{productId}")
+    public ResponseEntity<Void> changeProduct(
+            @PathVariable Long productId
+    ) {
+        productService.changeProductSailedStatus(productId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("product")
+    public ResponseEntity<Void> postProduct(
+            @RequestBody ProductRequestDto productRequestDto
+    ) {
+        productService.createNewProduct(productRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("product/{productId}")
+    public ResponseEntity<Void> deleteProduct(
+            @PathVariable Long productId
+    ) {
+        productService.delete(productId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/rootandfruit/server/domain/Product.java
+++ b/src/main/java/com/rootandfruit/server/domain/Product.java
@@ -72,4 +72,8 @@ public class Product extends BaseTimeEntity {
     public void switchSailedStatus(boolean isSailed) {
         this.isSailed = !isSailed;
     }
+
+    public void deleteProduct() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/rootandfruit/server/domain/Product.java
+++ b/src/main/java/com/rootandfruit/server/domain/Product.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,5 +33,43 @@ public class Product extends BaseTimeEntity {
     private boolean isSailed ;
 
     @Column(name = "is_deleted")
-    private boolean is_deleted ;
+    private boolean isDeleted ;
+
+    @Column(name = "is_trial")
+    private boolean isTrial;
+
+    @Builder
+    private Product(
+            final String productName,
+            final int price,
+            final boolean isTrial,
+            final boolean isSailed,
+            final boolean isDeleted
+    ) {
+        this.productName = productName;
+        this.price = price;
+        this.isTrial = isTrial;
+        this.isSailed = isSailed;
+        this.isDeleted = isDeleted;
+    }
+
+    public static Product createProduct(
+            final String productName,
+            final int price,
+            final boolean isTrial,
+            final boolean isSailed,
+            final boolean isDeleted
+    ) {
+        return Product.builder()
+                .productName(productName)
+                .price(price)
+                .isTrial(isTrial)
+                .isSailed(isSailed)
+                .isDeleted(isDeleted)
+                .build();
+    }
+
+    public void switchSailedStatus(boolean isSailed) {
+        this.isSailed = !isSailed;
+    }
 }

--- a/src/main/java/com/rootandfruit/server/dto/ProductRequestDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/ProductRequestDto.java
@@ -1,0 +1,8 @@
+package com.rootandfruit.server.dto;
+
+public record ProductRequestDto(
+        String productName,
+        int productPrice,
+        boolean isTrial
+) {
+}

--- a/src/main/java/com/rootandfruit/server/dto/ProductResponseDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/ProductResponseDto.java
@@ -1,0 +1,17 @@
+package com.rootandfruit.server.dto;
+
+import java.util.List;
+
+public record ProductResponseDto(
+        List<ProductTmpDto> trialProductList,
+        List<ProductTmpDto> productList
+) {
+    public static ProductResponseDto of(
+            final List<ProductTmpDto> trialProductList,
+            final List<ProductTmpDto> productList
+    ) {
+        return new ProductResponseDto(
+                trialProductList, productList
+        );
+    }
+}

--- a/src/main/java/com/rootandfruit/server/dto/ProductSailedResponseDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/ProductSailedResponseDto.java
@@ -1,0 +1,13 @@
+package com.rootandfruit.server.dto;
+
+import java.util.List;
+
+public record ProductSailedResponseDto(
+    List<ProductTmpDto> sailedProductList
+) {
+    public static ProductSailedResponseDto of(
+            final List<ProductTmpDto> sailedProductList
+    ) {
+        return new ProductSailedResponseDto(sailedProductList);
+    }
+}

--- a/src/main/java/com/rootandfruit/server/dto/ProductTmpDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/ProductTmpDto.java
@@ -1,0 +1,19 @@
+package com.rootandfruit.server.dto;
+
+public record ProductTmpDto(
+        Long productId,
+        String productName,
+        int productPrice
+
+) {
+    public static ProductTmpDto of(
+            final Long productId,
+            final String productName,
+            final int productPrice
+    ) {
+
+        return new ProductTmpDto(
+                productId, productName, productPrice
+        );
+    }
+}

--- a/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
@@ -19,6 +19,7 @@ public enum ErrorType {
     INVALID_HTTP_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "40004", "요청 형식이 허용된 형식과 다릅니다."),
     INVALID_HTTP_METHOD_ERROR(HttpStatus.BAD_REQUEST, "40005", "지원되지 않는 HTTP method 요청입니다."),
     INVALID_DELIVERY_STATUS_ERROR(HttpStatus.BAD_REQUEST, "40006", "잘못된 배송상태가 입력되었습니다."),
+    ALREADY_DELETED_PRODUCT(HttpStatus.BAD_REQUEST, "40007", "이미 삭제된 상품입니다."),
 
     /**
      * 404 NOT FOUND

--- a/src/main/java/com/rootandfruit/server/repository/ProductRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/ProductRepository.java
@@ -3,8 +3,10 @@ package com.rootandfruit.server.repository;
 import com.rootandfruit.server.domain.Product;
 import com.rootandfruit.server.global.exception.CustomException;
 import com.rootandfruit.server.global.exception.ErrorType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findProductById(Long id);
@@ -13,4 +15,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
         return findProductById(id)
                 .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_PRODUCT_ERROR));
     }
+
+    @Query("SELECT p FROM Product p WHERE p.isDeleted = false")
+    List<Product> findAllActiveProducts();
+
+    @Query("SELECT p FROM Product p WHERE p.isDeleted = false and p.isSailed = true")
+    List<Product> findSailedProducts();
 }

--- a/src/main/java/com/rootandfruit/server/service/ProductService.java
+++ b/src/main/java/com/rootandfruit/server/service/ProductService.java
@@ -1,0 +1,80 @@
+package com.rootandfruit.server.service;
+
+import com.rootandfruit.server.domain.Product;
+import com.rootandfruit.server.dto.ProductRequestDto;
+import com.rootandfruit.server.dto.ProductResponseDto;
+import com.rootandfruit.server.dto.ProductSailedResponseDto;
+import com.rootandfruit.server.dto.ProductTmpDto;
+import com.rootandfruit.server.repository.ProductRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = true)
+    public ProductResponseDto getAllProducts() {
+        List<Product> products = productRepository.findAllActiveProducts();
+
+        List<ProductTmpDto> trialProducts = products.stream()
+                .filter(Product::isTrial)
+                .map(this::toProductTmpDto)
+                .toList();
+
+        List<ProductTmpDto> sailedProducts = products.stream()
+                .filter(product -> !product.isTrial())
+                .map(this::toProductTmpDto)
+                .toList();
+
+        return ProductResponseDto.of(trialProducts, sailedProducts);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductSailedResponseDto getSailedProducts() {
+        List<Product> products = productRepository.findSailedProducts();
+
+        List<ProductTmpDto> sailedProducts = products.stream()
+                .map(this::toProductTmpDto)
+                .toList();
+        return ProductSailedResponseDto.of(sailedProducts);
+    }
+
+    private ProductTmpDto toProductTmpDto(Product product) {
+        return ProductTmpDto.of(
+                product.getId(),
+                product.getProductName(),
+                product.getPrice()
+        );
+    }
+
+    @Transactional
+    public void changeProductSailedStatus(Long productId) {
+        Product product = productRepository.findProductByIdOrThrow(productId);
+
+        product.switchSailedStatus(product.isSailed());
+    }
+
+    public void createNewProduct(ProductRequestDto productRequestDto) {
+        productRepository.save(
+                Product.createProduct(
+                        productRequestDto.productName(),
+                        productRequestDto.productPrice(),
+                        productRequestDto.isTrial(),
+                        false,
+                        false
+                )
+        );
+    }
+
+    @Transactional
+    public void delete(Long productId) {
+        Product product = productRepository.findProductByIdOrThrow(productId);
+
+        productRepository.delete(product);
+    }
+}

--- a/src/main/java/com/rootandfruit/server/service/ProductService.java
+++ b/src/main/java/com/rootandfruit/server/service/ProductService.java
@@ -5,6 +5,8 @@ import com.rootandfruit.server.dto.ProductRequestDto;
 import com.rootandfruit.server.dto.ProductResponseDto;
 import com.rootandfruit.server.dto.ProductSailedResponseDto;
 import com.rootandfruit.server.dto.ProductTmpDto;
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
 import com.rootandfruit.server.repository.ProductRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +57,9 @@ public class ProductService {
     @Transactional
     public void changeProductSailedStatus(Long productId) {
         Product product = productRepository.findProductByIdOrThrow(productId);
-
+        if (product.isDeleted()) {
+            throw new CustomException(ErrorType.ALREADY_DELETED_PRODUCT);
+        }
         product.switchSailedStatus(product.isSailed());
     }
 
@@ -74,7 +78,9 @@ public class ProductService {
     @Transactional
     public void delete(Long productId) {
         Product product = productRepository.findProductByIdOrThrow(productId);
-
-        productRepository.delete(product);
+        if (product.isDeleted()) {
+            throw new CustomException(ErrorType.ALREADY_DELETED_PRODUCT);
+        }
+        product.deleteProduct();
     }
 }


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
- close #11 

## 💻 작업 내용
<!-- 작업한 내용 리뷰어가 보기 편하게 기록해두기 -->
- 전체 상품을 조회하는 API를 구현했습니다. 삭제되지 않은 (isDeleted 속성이 false)인 상품 리스트를 응답으로 내려줍니다.
- 주문 서비스에서 보여주기 위한 현재 판매중인 상품 리스트를 응답으로 내려주는 API를 구현했습니다.
- 추후, 특정 상품의 판매량이나 주문 횟수 등을 볼 수 있는 확장성을 고려해서 상품을 삭제시키더라도 디비에서 실제로 삭제하지 않고, isDeleted속성만 변경해주었습니다.
- 토글을 누르면 판매중 <-> 판매중X 으로 판매 상태를 변경시키는 API를 구현했습니다. 