### PR TITLE
[FEAT] 결제, 배송 관련 API 구현

### DIFF
--- a/src/main/java/com/rootandfruit/server/controller/DeliveryController.java
+++ b/src/main/java/com/rootandfruit/server/controller/DeliveryController.java
@@ -1,0 +1,26 @@
+package com.rootandfruit.server.controller;
+
+import com.rootandfruit.server.service.DeliveryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/")
+@RequiredArgsConstructor
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    @PatchMapping("/delivery/shipped")
+    public ResponseEntity<Void> statusToShipped(
+            @RequestBody List<Long> deliveryInfoIds
+    ) {
+        deliveryService.statusCompletedToShipped(deliveryInfoIds);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/rootandfruit/server/controller/DeliveryController.java
+++ b/src/main/java/com/rootandfruit/server/controller/DeliveryController.java
@@ -4,7 +4,9 @@ import com.rootandfruit.server.service.DeliveryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +23,20 @@ public class DeliveryController {
             @RequestBody List<Long> deliveryInfoIds
     ) {
         deliveryService.statusCompletedToShipped(deliveryInfoIds);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("delivery/max")
+    public ResponseEntity<Integer> getAllowedDeliveryDay() {
+        return ResponseEntity.ok(deliveryService.getAllowedDay());
+    }
+
+    @PatchMapping("delivery/{allowedDeliveryDays}")
+    public ResponseEntity<Void> changeDay(
+            @PathVariable int allowedDeliveryDays
+    ) {
+
+        deliveryService.changeAllowedDay(allowedDeliveryDays);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/rootandfruit/server/controller/OrdersController.java
+++ b/src/main/java/com/rootandfruit/server/controller/OrdersController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,7 +27,7 @@ public class OrdersController {
     @PostMapping("order")
     public ResponseEntity<Void> order(
             @RequestBody OrderRequestDto orderRequestDto
-            ){
+    ) {
         ordersService.order(orderRequestDto);
         return ResponseEntity.ok().build();
     }
@@ -34,7 +35,7 @@ public class OrdersController {
     @GetMapping("order/{orderNumber}")
     public ResponseEntity<OrderNumberResponseDto> order(
             @PathVariable int orderNumber
-    ){
+    ) {
         return ResponseEntity.ok(ordersService.getOrderByOrderNumber(orderNumber));
     }
 
@@ -52,5 +53,21 @@ public class OrdersController {
                 productName,
                 deliveryStatus
         ));
+    }
+
+    @PatchMapping("order/pay/{orderNumber}")
+    public ResponseEntity<Void> orderPay(
+            @PathVariable int orderNumber
+    ) {
+        ordersService.pay(orderNumber);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("order/cancel/{orderNumber}")
+    public ResponseEntity<Void> orderCancel(
+            @PathVariable int orderNumber
+    ) {
+        ordersService.cancel(orderNumber);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/rootandfruit/server/controller/ProductController.java
+++ b/src/main/java/com/rootandfruit/server/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.rootandfruit.server.dto.ProductRequestDto;
 import com.rootandfruit.server.dto.ProductResponseDto;
 import com.rootandfruit.server.dto.ProductSailedResponseDto;
 import com.rootandfruit.server.service.ProductService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -50,9 +51,9 @@ public class ProductController {
 
     @DeleteMapping("product/{productId}")
     public ResponseEntity<Void> deleteProduct(
-            @PathVariable Long productId
+            @RequestBody List<Long> productIds
     ) {
-        productService.delete(productId);
+        productService.delete(productIds);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
+++ b/src/main/java/com/rootandfruit/server/domain/DeliveryInfo.java
@@ -92,4 +92,8 @@ public class DeliveryInfo extends BaseTimeEntity {
                 .deliveryStatus(DeliveryStatus.ORDER_ACCEPTED)
                 .build();
     }
+
+    public void changeDeliveryStatus(DeliveryStatus deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
+    }
 }

--- a/src/main/java/com/rootandfruit/server/domain/OrderMetaData.java
+++ b/src/main/java/com/rootandfruit/server/domain/OrderMetaData.java
@@ -32,4 +32,8 @@ public class OrderMetaData {
     public int incrementOrderNumberSequence() {
         return ++this.orderNumberSequence;
     }
+
+    public void changeAllowedDeliveryDays(int allowedDeliveryDays) {
+        this.allowedDeliveryDays = allowedDeliveryDays;
+    }
 }

--- a/src/main/java/com/rootandfruit/server/dto/OrderDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/OrderDto.java
@@ -1,27 +1,55 @@
 package com.rootandfruit.server.dto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record OrderDto(
+        Long deliveryId,
+        int orderNumber,
         String senderName,
+        String senderPhone,
         String recipientName,
-        String productName,
-        int productCount,
+        String recipientPhone,
+        String recipientAddress,
+        String recipientAddressDetail,
+        String recipientPostCode,
+        List<String> productList,
+        int productTotalCount,
         String deliveryStatus,
         LocalDate orderReceivedDate,
         LocalDate deliveryDate
 ) {
     public static OrderDto of(
+            final Long deliveryId,
+            final int orderNumber,
             final String senderName,
+            final String senderPhone,
             final String recipientName,
-            final String productName,
-            final int productCount,
+            final String recipientPhone,
+            final String recipientAddress,
+            final String recipientAddressDetail,
+            final String recipientPostCode,
+            final List<String> productList,
+            final int productTotalCount,
             final String deliveryStatus,
             final LocalDate orderReceivedDate,
-            final LocalDate deliveryDate
+            LocalDate deliveryDate
     ) {
         return new OrderDto(
-                senderName, recipientName, productName, productCount, deliveryStatus, orderReceivedDate, deliveryDate
+                deliveryId,
+                orderNumber,
+                senderName,
+                senderPhone,
+                recipientName,
+                recipientPhone,
+                recipientAddress,
+                recipientAddressDetail,
+                recipientPostCode,
+                productList,
+                productTotalCount,
+                deliveryStatus,
+                orderReceivedDate,
+                deliveryDate
         );
     }
 }

--- a/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
@@ -27,6 +27,8 @@ public enum ErrorType {
     NOT_FOUND_PRODUCT_ERROR(HttpStatus.NOT_FOUND, "40401", "존재하지 않는 상품입니다."),
     NOT_FOUND_ORDER_META_DATA_ERROR(HttpStatus.NOT_FOUND, "40402", "주문 메타데이터가 존재하지 않습니다."),
     NOT_FOUND_ORDER_ERROR(HttpStatus.NOT_FOUND, "40403", "주문번호에 대한 주문내역이 존재하지 않습니다."),
+    NOT_FOUND_DELIVERY_INFO_ERROR(HttpStatus.NOT_FOUND, "40404", "주문번호에 대한 배송정보가 존재하지 않습니다."),
+    NOT_FOUND_DELIVERY_ERROR(HttpStatus.NOT_FOUND, "40401", "존재하지 않는 베송정보입니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/com/rootandfruit/server/repository/DeliveryInfoRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/DeliveryInfoRepository.java
@@ -1,7 +1,12 @@
 package com.rootandfruit.server.repository;
 
 import com.rootandfruit.server.domain.DeliveryInfo;
+import com.rootandfruit.server.domain.Product;
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DeliveryInfoRepository extends JpaRepository<DeliveryInfo, Long> {
+
 }

--- a/src/main/java/com/rootandfruit/server/service/DeliveryService.java
+++ b/src/main/java/com/rootandfruit/server/service/DeliveryService.java
@@ -1,0 +1,28 @@
+package com.rootandfruit.server.service;
+
+import com.rootandfruit.server.domain.DeliveryInfo;
+import com.rootandfruit.server.domain.DeliveryStatus;
+import com.rootandfruit.server.domain.Product;
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
+import com.rootandfruit.server.repository.DeliveryInfoRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+
+    private final DeliveryInfoRepository deliveryInfoRepository;
+
+    @Transactional
+    public void statusCompletedToShipped(List<Long> deliveryInfoIds) {
+        List<DeliveryInfo> deliveryInfos = deliveryInfoRepository.findAllById(deliveryInfoIds);
+        if (deliveryInfos.isEmpty()) {
+            throw new CustomException(ErrorType.NOT_FOUND_DELIVERY_ERROR);
+        }
+        deliveryInfos.forEach(deliveryInfo -> deliveryInfo.changeDeliveryStatus(DeliveryStatus.ORDER_SHIPPED));
+    }
+}

--- a/src/main/java/com/rootandfruit/server/service/DeliveryService.java
+++ b/src/main/java/com/rootandfruit/server/service/DeliveryService.java
@@ -2,10 +2,12 @@ package com.rootandfruit.server.service;
 
 import com.rootandfruit.server.domain.DeliveryInfo;
 import com.rootandfruit.server.domain.DeliveryStatus;
+import com.rootandfruit.server.domain.OrderMetaData;
 import com.rootandfruit.server.domain.Product;
 import com.rootandfruit.server.global.exception.CustomException;
 import com.rootandfruit.server.global.exception.ErrorType;
 import com.rootandfruit.server.repository.DeliveryInfoRepository;
+import com.rootandfruit.server.repository.OrderMetaDataRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryService {
 
     private final DeliveryInfoRepository deliveryInfoRepository;
+    private final OrderMetaDataRepository orderMetaDataRepository;
 
     @Transactional
     public void statusCompletedToShipped(List<Long> deliveryInfoIds) {
@@ -24,5 +27,17 @@ public class DeliveryService {
             throw new CustomException(ErrorType.NOT_FOUND_DELIVERY_ERROR);
         }
         deliveryInfos.forEach(deliveryInfo -> deliveryInfo.changeDeliveryStatus(DeliveryStatus.ORDER_SHIPPED));
+    }
+
+    @Transactional(readOnly = true)
+    public int getAllowedDay() {
+        OrderMetaData orderMetaData = orderMetaDataRepository.findOrderMetaDataByIdOrThrow(1L);
+        return orderMetaData.getAllowedDeliveryDays();
+    }
+
+    @Transactional
+    public void changeAllowedDay(int allowedDeliveryDays) {
+        OrderMetaData orderMetaData = orderMetaDataRepository.findOrderMetaDataByIdOrThrow(1L);
+        orderMetaData.changeAllowedDeliveryDays(allowedDeliveryDays);
     }
 }

--- a/src/main/java/com/rootandfruit/server/service/ProductService.java
+++ b/src/main/java/com/rootandfruit/server/service/ProductService.java
@@ -76,11 +76,11 @@ public class ProductService {
     }
 
     @Transactional
-    public void delete(Long productId) {
-        Product product = productRepository.findProductByIdOrThrow(productId);
-        if (product.isDeleted()) {
-            throw new CustomException(ErrorType.ALREADY_DELETED_PRODUCT);
+    public void delete(List<Long> productIds) {
+        List<Product> products = productRepository.findAllById(productIds);
+        if (products.isEmpty()) {
+            throw new CustomException(ErrorType.NOT_FOUND_PRODUCT_ERROR);
         }
-        product.deleteProduct();
+        products.forEach(Product::deleteProduct);
     }
 }


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- close #13 

## 💻 작업 내용
<!-- 작업한 내용 리뷰어가 보기 편하게 기록해두기 -->
- 배송상태를 변경하는 API들을 구현했습니다.
- 필터링 정보를 기준으로 주문내역을 조회할 때, 배송정보를 기준으로 응답을 내려주도록 변경했습니다.
(송장정보와 조회정보를 모두 포함하도록 구현했습니다)
- 최대 배송날짜 조회, 수정 API를 구현했습니다.