### PR TITLE
[FEAT] 최근 접수 주문번호 조회 구현

### DIFF
--- a/src/main/java/com/rootandfruit/server/controller/OrdersController.java
+++ b/src/main/java/com/rootandfruit/server/controller/OrdersController.java
@@ -6,6 +6,7 @@ import com.rootandfruit.server.dto.OrderRequestDto;
 import com.rootandfruit.server.dto.OrderResponseDto;
 import com.rootandfruit.server.service.OrdersService;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -68,5 +69,10 @@ public class OrdersController implements OrdersControllerDocs {
     ) {
         ordersService.cancel(orderNumber);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("order/recent")
+    public ResponseEntity<List<Integer>> getRecentOrderNumber() {
+        return ResponseEntity.ok(ordersService.getRecentTen());
     }
 }

--- a/src/main/java/com/rootandfruit/server/controller/OrdersController.java
+++ b/src/main/java/com/rootandfruit/server/controller/OrdersController.java
@@ -44,14 +44,16 @@ public class OrdersController implements OrdersControllerDocs {
             @RequestParam(required = false) final LocalDate orderReceivedDate,
             @RequestParam(required = false) final LocalDate deliveryDate,
             @RequestParam(required = false) final String productName,
-            @RequestParam(required = false) final String deliveryStatus
+            @RequestParam(required = false) final String deliveryStatus,
+            @RequestParam(required = false) final boolean isTrial
     ) {
 
         return ResponseEntity.ok(ordersService.searchOrder(
                 orderReceivedDate,
                 deliveryDate,
                 productName,
-                deliveryStatus
+                deliveryStatus,
+                isTrial
         ));
     }
 

--- a/src/main/java/com/rootandfruit/server/controller/docs/DeliveryControllerDocs.java
+++ b/src/main/java/com/rootandfruit/server/controller/docs/DeliveryControllerDocs.java
@@ -41,8 +41,7 @@ public interface DeliveryControllerDocs {
     ResponseEntity<Void> changeDay(
             @Parameter(
                     description = "변경할 최대 배송 가능일 (예: 7일, 14일)",
-                    required = true,
-                    schema = @Schema(type = "int", example = "10")
+                    required = true
             )
             @PathVariable int allowedDeliveryDays
     );

--- a/src/main/java/com/rootandfruit/server/controller/docs/OrdersControllerDocs.java
+++ b/src/main/java/com/rootandfruit/server/controller/docs/OrdersControllerDocs.java
@@ -39,8 +39,7 @@ public interface OrdersControllerDocs {
     ResponseEntity<OrderNumberResponseDto> order(
             @Parameter(
                     description = "조회할 주문의 주문번호",
-                    required = true,
-                    schema = @Schema(type = "int", example = "1002")
+                    required = true
             )
             @PathVariable int orderNumber
     );
@@ -84,8 +83,7 @@ public interface OrdersControllerDocs {
     ResponseEntity<Void> orderPay(
             @Parameter(
                     description = "결제할 주문의 번호",
-                    required = true,
-                    schema = @Schema(type = "int", example = "1002")
+                    required = true
             )
             @PathVariable int orderNumber
     );
@@ -98,8 +96,7 @@ public interface OrdersControllerDocs {
     ResponseEntity<Void> orderCancel(
             @Parameter(
                     description = "취소할 주문의 번호",
-                    required = true,
-                    schema = @Schema(type = "int", example = "1002")
+                    required = true
             )
             @PathVariable int orderNumber
     );

--- a/src/main/java/com/rootandfruit/server/controller/docs/OrdersControllerDocs.java
+++ b/src/main/java/com/rootandfruit/server/controller/docs/OrdersControllerDocs.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -100,4 +101,10 @@ public interface OrdersControllerDocs {
             )
             @PathVariable int orderNumber
     );
+
+    @Operation(summary = "최근 접수 주문번호 조회", description = "최근 접수한 10개의 주문번호를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "주분번호 조회 성공")
+    })
+    ResponseEntity<List<Integer>> getRecentOrderNumber();
 }

--- a/src/main/java/com/rootandfruit/server/controller/docs/OrdersControllerDocs.java
+++ b/src/main/java/com/rootandfruit/server/controller/docs/OrdersControllerDocs.java
@@ -56,24 +56,33 @@ public interface OrdersControllerDocs {
                     schema = @Schema(type = "string", format = "date", example = "2024-09-01")
             )
             @RequestParam(required = false) final LocalDate orderReceivedDate,
+
             @Parameter(
                     description = "배송 예정 날짜 (사실 출발 날짜임)",
                     required = false,
                     schema = @Schema(type = "string", format = "date", example = "2024-09-10")
             )
             @RequestParam(required = false) final LocalDate deliveryDate,
+
             @Parameter(
                     description = "주문 상품 이름",
                     required = false,
                     schema = @Schema(type = "string", example = "귤 몇kg")
             )
             @RequestParam(required = false) final String productName,
+
             @Parameter(
                     description = "배송 상태 (예: '접수완료', '결제완료', '결제취소', '발송완료')",
                     required = false,
                     schema = @Schema(type = "string", example = "접수완료")
             )
-            @RequestParam(required = false) final String deliveryStatus
+            @RequestParam(required = false) final String deliveryStatus,
+
+            @Parameter(
+                    description = "체험 상품 여부",
+                    required = false
+            )
+            @RequestParam(required = false) final boolean isTrial
     );
 
     @Operation(summary = "주문 결제 처리", description = "주문 번호를 이용해 주문을 결제 처리합니다.")

--- a/src/main/java/com/rootandfruit/server/repository/OrdersCustomRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersCustomRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface OrdersCustomRepository {
     List<Orders> searchOrders(LocalDate orderReceivedDate, LocalDate deliveryDate, String productName,
-                              DeliveryStatus deliveryStatus);
+                              DeliveryStatus deliveryStatus, boolean isTrial);
 }

--- a/src/main/java/com/rootandfruit/server/repository/OrdersRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersRepository.java
@@ -1,10 +1,14 @@
 package com.rootandfruit.server.repository;
 
+import com.rootandfruit.server.domain.DeliveryStatus;
 import com.rootandfruit.server.domain.Orders;
 import com.rootandfruit.server.global.exception.CustomException;
 import com.rootandfruit.server.global.exception.ErrorType;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrdersRepository extends JpaRepository<Orders, Long>, OrdersCustomRepository {
     List<Orders> findByOrderNumber(int orderNumber);
@@ -16,4 +20,13 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, OrdersCus
         }
         return orders;
     }
+
+    @Query("SELECT o.orderNumber FROM Orders o " +
+            "JOIN o.deliveryInfo d " +
+            "WHERE d.deliveryStatus = :deliveryStatus " +
+            "ORDER BY o.createdAt DESC")
+    List<Integer> findDistinctOrderNumbersByDeliveryStatus(
+            @Param("deliveryStatus") DeliveryStatus deliveryStatus,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/rootandfruit/server/repository/OrdersRepositoryImpl.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersRepositoryImpl.java
@@ -39,7 +39,7 @@ public class OrdersRepositoryImpl implements OrdersCustomRepository{
     }
 
     private BooleanExpression ltDeliveryDate(LocalDate deliveryDate) {
-        return deliveryDate != null ? QDeliveryInfo.deliveryInfo.deliveryDate.before(deliveryDate) : null;
+        return deliveryDate != null ? QDeliveryInfo.deliveryInfo.deliveryDate.loe(deliveryDate) : null;
     }
 
     private BooleanExpression eqProductName(String productName) {

--- a/src/main/java/com/rootandfruit/server/repository/OrdersRepositoryImpl.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersRepositoryImpl.java
@@ -22,7 +22,7 @@ public class OrdersRepositoryImpl implements OrdersCustomRepository{
 
     @Override
     public List<Orders> searchOrders(LocalDate orderReceivedDate, LocalDate deliveryDate, String productName,
-                                     DeliveryStatus deliveryStatus) {
+                                     DeliveryStatus deliveryStatus, boolean isTrial) {
         return queryFactory
                 .selectFrom(orders)
                 .join(orders.deliveryInfo, QDeliveryInfo.deliveryInfo)
@@ -33,7 +33,8 @@ public class OrdersRepositoryImpl implements OrdersCustomRepository{
                                 .and(orders.createdAt.dayOfMonth().eq(orderReceivedDate.getDayOfMonth())) : null,
                         ltDeliveryDate(deliveryDate),
                         eqProductName(productName),
-                        eqDeliveryStatus(deliveryStatus)
+                        eqDeliveryStatus(deliveryStatus),
+                        eqIsTrial(isTrial)
                 )
                 .orderBy(QDeliveryInfo.deliveryInfo.deliveryDate.asc())
                 .fetch();
@@ -50,5 +51,9 @@ public class OrdersRepositoryImpl implements OrdersCustomRepository{
     private BooleanExpression eqDeliveryStatus(DeliveryStatus deliveryStatus) {
         return deliveryStatus != null ? QDeliveryInfo.deliveryInfo.deliveryStatus.eq(
                 deliveryStatus) : null;
+    }
+
+    private BooleanExpression eqIsTrial(boolean isTrial) {
+        return QProduct.product.isTrial.eq(isTrial);
     }
 }

--- a/src/main/java/com/rootandfruit/server/repository/OrdersRepositoryImpl.java
+++ b/src/main/java/com/rootandfruit/server/repository/OrdersRepositoryImpl.java
@@ -35,6 +35,7 @@ public class OrdersRepositoryImpl implements OrdersCustomRepository{
                         eqProductName(productName),
                         eqDeliveryStatus(deliveryStatus)
                 )
+                .orderBy(QDeliveryInfo.deliveryInfo.deliveryDate.asc())
                 .fetch();
     }
 

--- a/src/main/java/com/rootandfruit/server/service/OrdersService.java
+++ b/src/main/java/com/rootandfruit/server/service/OrdersService.java
@@ -108,6 +108,12 @@ public class OrdersService {
                 .collect(Collectors.groupingBy(order -> order.getDeliveryInfo().getId()));
 
         List<OrderDto> orderDtoList = ordersByDeliveryInfo.entrySet().stream()
+                .sorted((entry1, entry2) -> {
+                    // 각 entry의 value(Orders 리스트)에서 첫 번째 주문의 deliveryDate로 비교
+                    LocalDate deliveryDate1 = entry1.getValue().get(0).getDeliveryInfo().getDeliveryDate();
+                    LocalDate deliveryDate2 = entry2.getValue().get(0).getDeliveryInfo().getDeliveryDate();
+                    return deliveryDate1.compareTo(deliveryDate2); // 오름차순 정렬
+                })
                 .map(entry -> toOrderDto(entry.getKey(), entry.getValue())) // key는 배송정보 ID, value는 해당 배송에 속한 주문 리스트
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/rootandfruit/server/service/OrdersService.java
+++ b/src/main/java/com/rootandfruit/server/service/OrdersService.java
@@ -21,7 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +37,7 @@ public class OrdersService {
     private final OrderMetaDataRepository orderMetaDataRepository;
 
     @Transactional
-    public int order(OrderRequestDto orderRequestDto){
+    public int order(OrderRequestDto orderRequestDto) {
         Member member = Member.createMember(orderRequestDto.senderName(), orderRequestDto.senderPhone(),
                 orderRequestDto.isMarketingConsent());
         memberRepository.save(member);
@@ -164,5 +165,13 @@ public class OrdersService {
             DeliveryInfo deliveryInfo = order.getDeliveryInfo();
             deliveryInfo.changeDeliveryStatus(DeliveryStatus.PAYMENT_CANCELED);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<Integer> getRecentTen() {
+        Pageable limitTen = PageRequest.of(0, 10);
+        List<Integer> orderNumbers = ordersRepository.findDistinctOrderNumbersByDeliveryStatus(DeliveryStatus.ORDER_ACCEPTED, limitTen);
+
+        return orderNumbers.stream().distinct().collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/rootandfruit/server/service/OrdersService.java
+++ b/src/main/java/com/rootandfruit/server/service/OrdersService.java
@@ -93,15 +93,15 @@ public class OrdersService {
 
     @Transactional(readOnly = true)
     public OrderResponseDto searchOrder(LocalDate orderReceivedDate, LocalDate deliveryDate, String productName,
-                                        String deliveryStatus) {
-
+                                        String deliveryStatus, boolean isTrail) {
         DeliveryStatus status = null;
         if (deliveryStatus != null) {
             status = DeliveryStatus.fromString(deliveryStatus);
         }
 
         // 주문 목록 조회 (여기서 각 주문은 하나의 배송 정보에 속함)
-        List<Orders> orderList = ordersRepository.searchOrders(orderReceivedDate, deliveryDate, productName, status);
+        List<Orders> orderList = ordersRepository.searchOrders(orderReceivedDate, deliveryDate, productName, status,
+                isTrail);
 
         // 배송 정보별로 주문을 묶고 OrderDto로 변환
         Map<Long, List<Orders>> ordersByDeliveryInfo = orderList.stream()


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- close #20 

## 💻 작업 내용
<!-- 작업한 내용 리뷰어가 보기 편하게 기록해두기 -->
-  최근 접수 주문번호 조회 API 추가
- 스웨거 path variable 오류 해결
- 판매/체험 상품 필터링 추가
- 출발날짜 이하 & 출발 날짜 순으로 정렬 필터링 추가