### PR TITLE
[FEAT] 관리자 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0' // 쿼리 파라미터 로그 남기기
 
+    // INCODING
+    implementation 'org.mindrot:jbcrypt:0.4'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/rootandfruit/server/controller/AdminController.java
+++ b/src/main/java/com/rootandfruit/server/controller/AdminController.java
@@ -1,0 +1,35 @@
+package com.rootandfruit.server.controller;
+
+import com.rootandfruit.server.controller.docs.AdminControllerDocs;
+import com.rootandfruit.server.dto.AdminAuthenticateRequestDto;
+import com.rootandfruit.server.dto.AdminCreateRequestDto;
+import com.rootandfruit.server.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminController implements AdminControllerDocs {
+    private final AdminService adminService;
+
+    @PostMapping("/create")
+    public ResponseEntity<Void> createAdmin(
+            @RequestBody AdminCreateRequestDto adminCreateRequestDto
+    ) {
+        adminService.createAdmin(adminCreateRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/authenticate")
+    public ResponseEntity<Void> authenticateAdmin(
+            @RequestBody AdminAuthenticateRequestDto adminAuthenticateRequestDto
+            ) {
+        adminService.authenticateAdmin(adminAuthenticateRequestDto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/rootandfruit/server/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/com/rootandfruit/server/controller/docs/AdminControllerDocs.java
@@ -1,0 +1,45 @@
+package com.rootandfruit.server.controller.docs;
+
+import com.rootandfruit.server.dto.AdminAuthenticateRequestDto;
+import com.rootandfruit.server.dto.AdminCreateRequestDto;
+import com.rootandfruit.server.dto.OrderRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin", description = "Admin 관련 API")
+public interface AdminControllerDocs {
+
+    @Operation(summary = "관리자 계정 생성", description = "관리자 계정을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "관리자 계성 생성 성공")
+    })
+    ResponseEntity<Void> createAdmin(
+            @Parameter(
+                    description = "생성할 관리자 계정 정보",
+                    required = true,
+                    schema = @Schema(implementation = AdminCreateRequestDto.class)
+            )
+            @RequestBody AdminCreateRequestDto adminCreateRequestDto
+    );
+
+    @Operation(summary = "관리자 계정 로그인", description = "관리자 계정으로 로그인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "관리자 로그인 성공"),
+            @ApiResponse(responseCode = "40406", description = "관리자 아이디 불일치"),
+            @ApiResponse(responseCode = "40008", description = "관리자 비밀번호 불일치")
+    })
+    ResponseEntity<Void> authenticateAdmin(
+            @Parameter(
+                    description = "관리자 아이디, 비밀번호",
+                    required = true,
+                    schema = @Schema(implementation = AdminAuthenticateRequestDto.class)
+            )
+            @RequestBody AdminAuthenticateRequestDto adminAuthenticateRequestDto
+    );
+}

--- a/src/main/java/com/rootandfruit/server/domain/Admin.java
+++ b/src/main/java/com/rootandfruit/server/domain/Admin.java
@@ -1,0 +1,47 @@
+package com.rootandfruit.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.mindrot.jbcrypt.BCrypt;
+import jakarta.persistence.Id;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "admin")
+public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Builder
+    private Admin(final String username, final String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public static Admin createAdmin(final String username, final String rawPassword) {
+        // BCrypt를 사용해 비밀번호를 인코딩
+        String encodedPassword = BCrypt.hashpw(rawPassword, BCrypt.gensalt());
+        return Admin.builder()
+                .username(username)
+                .password(encodedPassword)
+                .build();
+    }
+}

--- a/src/main/java/com/rootandfruit/server/dto/AdminAuthenticateRequestDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/AdminAuthenticateRequestDto.java
@@ -1,0 +1,7 @@
+package com.rootandfruit.server.dto;
+
+public record AdminAuthenticateRequestDto(
+        String username,
+        String password
+) {
+}

--- a/src/main/java/com/rootandfruit/server/dto/AdminCreateRequestDto.java
+++ b/src/main/java/com/rootandfruit/server/dto/AdminCreateRequestDto.java
@@ -1,0 +1,7 @@
+package com.rootandfruit.server.dto;
+
+public record AdminCreateRequestDto(
+        String username,
+        String password
+) {
+}

--- a/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
+++ b/src/main/java/com/rootandfruit/server/global/exception/ErrorType.java
@@ -20,6 +20,7 @@ public enum ErrorType {
     INVALID_HTTP_METHOD_ERROR(HttpStatus.BAD_REQUEST, "40005", "지원되지 않는 HTTP method 요청입니다."),
     INVALID_DELIVERY_STATUS_ERROR(HttpStatus.BAD_REQUEST, "40006", "잘못된 배송상태가 입력되었습니다."),
     ALREADY_DELETED_PRODUCT(HttpStatus.BAD_REQUEST, "40007", "이미 삭제된 상품입니다."),
+    INVALID_ADMIN_PASSWORD(HttpStatus.BAD_REQUEST, "40008", "비밀번호가 일치하지 않습니다."),
 
     /**
      * 404 NOT FOUND
@@ -29,6 +30,7 @@ public enum ErrorType {
     NOT_FOUND_ORDER_ERROR(HttpStatus.NOT_FOUND, "40403", "주문번호에 대한 주문내역이 존재하지 않습니다."),
     NOT_FOUND_DELIVERY_INFO_ERROR(HttpStatus.NOT_FOUND, "40404", "주문번호에 대한 배송정보가 존재하지 않습니다."),
     NOT_FOUND_DELIVERY_ERROR(HttpStatus.NOT_FOUND, "40405", "존재하지 않는 베송정보입니다."),
+    NOT_FOUND_ADMIN_ERROR(HttpStatus.NOT_FOUND, "40406", "존재하지 않는 관리자 계정입니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/com/rootandfruit/server/repository/AdminRepository.java
+++ b/src/main/java/com/rootandfruit/server/repository/AdminRepository.java
@@ -1,0 +1,18 @@
+package com.rootandfruit.server.repository;
+
+import com.rootandfruit.server.domain.Admin;
+import com.rootandfruit.server.domain.OrderMetaData;
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findAdminByUsername(String username);
+
+    default Admin findAdminByUsernameOrThrow(String username) {
+        return findAdminByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_ADMIN_ERROR));
+    }
+}

--- a/src/main/java/com/rootandfruit/server/service/AdminService.java
+++ b/src/main/java/com/rootandfruit/server/service/AdminService.java
@@ -1,0 +1,33 @@
+package com.rootandfruit.server.service;
+
+import com.rootandfruit.server.domain.Admin;
+import com.rootandfruit.server.dto.AdminAuthenticateRequestDto;
+import com.rootandfruit.server.dto.AdminCreateRequestDto;
+import com.rootandfruit.server.global.exception.CustomException;
+import com.rootandfruit.server.global.exception.ErrorType;
+import com.rootandfruit.server.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+
+    @Transactional
+    public void createAdmin(AdminCreateRequestDto adminCreateRequestDto) {
+        Admin admin = Admin.createAdmin(adminCreateRequestDto.username(), adminCreateRequestDto.password());
+        adminRepository.save(admin);
+    }
+
+    @Transactional(readOnly = true)
+    public void authenticateAdmin(AdminAuthenticateRequestDto adminAuthenticateRequestDto) {
+        Admin admin = adminRepository.findAdminByUsernameOrThrow(adminAuthenticateRequestDto.username());
+        if (!BCrypt.checkpw(adminAuthenticateRequestDto.password(), admin.getPassword())) {
+            throw new CustomException(ErrorType.INVALID_ADMIN_PASSWORD);
+        }
+    }
+}


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- close #24 

## 💻 작업 내용
<!-- 작업한 내용 리뷰어가 보기 편하게 기록해두기 -->
- 관리자 인증을 구현했습니다.
- Spring Security는 사용하지 않고, 관리자 계정 생성 시 비밀번호만 인코딩해서 저장, 후에도 요청받은 비밀번호를 인코딩하여 비교하는 방식으로 간단한 인증을 구현했습니다.
