### PR TITLE
[FIX] 최신 접수 주문 번호 중복 제거 및 상태 추가

### DIFF
--- a/src/main/java/com/rootandfruit/server/api/controller/OrdersController.java
+++ b/src/main/java/com/rootandfruit/server/api/controller/OrdersController.java
@@ -77,6 +77,6 @@ public class OrdersController implements OrdersControllerDocs {
 
     @GetMapping("order/recent")
     public ResponseEntity<List<RecentOrderResponseDto>> getRecentOrderNumber() {
-        return ResponseEntity.ok(ordersService.getRecentTen());
+        return ResponseEntity.ok(ordersService.getRecentOrders());
     }
 }

--- a/src/main/java/com/rootandfruit/server/api/dto/RecentOrderResponseDto.java
+++ b/src/main/java/com/rootandfruit/server/api/dto/RecentOrderResponseDto.java
@@ -1,15 +1,34 @@
 package com.rootandfruit.server.api.dto;
 
+import com.rootandfruit.server.api.domain.DeliveryStatus;
+
 public record RecentOrderResponseDto(
         Integer orderNumber,
-        String senderName
+        String senderName,
+        String deliveryStatus
 ) {
+    // 생성자 추가
+    public RecentOrderResponseDto(Integer orderNumber, String senderName, DeliveryStatus deliveryStatus) {
+        this(orderNumber, senderName, convertStatusToKorean(deliveryStatus));
+    }
+
     public static RecentOrderResponseDto of(
             final Integer orderNumber,
-            final String senderName
+            final String senderName,
+            final DeliveryStatus deliveryStatus
     ) {
         return new RecentOrderResponseDto(
-                orderNumber, senderName
+                orderNumber, senderName, convertStatusToKorean(deliveryStatus)
         );
+    }
+
+    private static String convertStatusToKorean(DeliveryStatus deliveryStatus) {
+        return switch (deliveryStatus) {
+            case ORDER_ACCEPTED -> "접수완료";
+            case PAYMENT_COMPLETED -> "결제완료";
+            case PAYMENT_CANCELED -> "결제취소";
+            case ORDER_SHIPPED -> "발송완료";
+            default -> "알 수 없음";
+        };
     }
 }

--- a/src/main/java/com/rootandfruit/server/api/repository/OrdersRepository.java
+++ b/src/main/java/com/rootandfruit/server/api/repository/OrdersRepository.java
@@ -6,6 +6,7 @@ import com.rootandfruit.server.api.dto.RecentOrderResponseDto;
 import com.rootandfruit.server.global.exception.CustomException;
 import com.rootandfruit.server.global.exception.ErrorType;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,13 +23,9 @@ public interface OrdersRepository extends JpaRepository<Orders, Long>, OrdersCus
         return orders;
     }
 
-    @Query("SELECT new com.rootandfruit.server.api.dto.RecentOrderResponseDto(o.orderNumber, d.senderName) " +
+    @Query("SELECT DISTINCT new com.rootandfruit.server.api.dto.RecentOrderResponseDto(o.orderNumber, d.senderName, d.deliveryStatus) " +
             "FROM Orders o " +
             "JOIN o.deliveryInfo d " +
-            "WHERE d.deliveryStatus = :deliveryStatus " +
-            "ORDER BY o.createdAt DESC")
-    List<RecentOrderResponseDto> findRecentOrdersByDeliveryStatus(
-            @Param("deliveryStatus") DeliveryStatus deliveryStatus,
-            Pageable pageable
-    );
+            "ORDER BY o.orderNumber DESC")
+    List<RecentOrderResponseDto> findRecentOrders();
 }

--- a/src/main/java/com/rootandfruit/server/api/service/OrdersService.java
+++ b/src/main/java/com/rootandfruit/server/api/service/OrdersService.java
@@ -175,8 +175,17 @@ public class OrdersService {
     }
 
     @Transactional(readOnly = true)
-    public List<RecentOrderResponseDto> getRecentTen() {
-        Pageable limitTen = PageRequest.of(0, 10);
-        return ordersRepository.findRecentOrdersByDeliveryStatus(DeliveryStatus.ORDER_ACCEPTED, limitTen);
+    public List<RecentOrderResponseDto> getRecentOrders() {
+        List<RecentOrderResponseDto> recentOrders = ordersRepository.findRecentOrders();
+
+        return recentOrders.stream()
+                .limit(10)
+                .map(order -> RecentOrderResponseDto.of(
+                        order.orderNumber(),
+                        order.senderName(),
+                        DeliveryStatus.fromString(order.deliveryStatus())// 여기서는 DeliveryStatus 타입을 그대로 전달
+                ))
+                .collect(Collectors.toList());
     }
 }
+


### PR DESCRIPTION
### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
- close #30 

## 💻 작업 내용
<!-- 작업한 내용 리뷰어가 보기 편하게 기록해두기 -->
- 최근 접수된 주문번호 10개를 내려줄 때, 주문번호의 중복을 제거하고 배송상태를 추가해주었습니다.